### PR TITLE
fix(database/repository): Ajuste na consulta do repositório

### DIFF
--- a/src/main/java/br/com/banco/controllers/TransferenciaController.java
+++ b/src/main/java/br/com/banco/controllers/TransferenciaController.java
@@ -29,13 +29,11 @@ public class TransferenciaController {
     public List<Transferencia> obterTransferenciasPorPeriodo(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dataInicio,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dataFim) {
-        System.out.println("rota em uso");
         return transferenciaService.obterTransferenciasPorPeriodo(dataInicio, dataFim);
     }
 
     @GetMapping("/operador")
     public List<Transferencia> obterTransferenciasPorOperador(@RequestParam String nomeOperador) {
-        System.out.println("rota em uso");
         return transferenciaService.obterTransferenciasPorOperador(nomeOperador);
     }
 

--- a/src/main/java/br/com/banco/repository/TransferenciaRepository.java
+++ b/src/main/java/br/com/banco/repository/TransferenciaRepository.java
@@ -14,9 +14,9 @@ import java.util.List;
 public interface TransferenciaRepository extends JpaRepository<Transferencia, Long> {
     @Query("SELECT t FROM Transferencia t WHERE t.dataTransferencia BETWEEN :dataInicio AND :dataFim")
     List<Transferencia> findByDataTransferenciaBetween(LocalDateTime dataInicio, LocalDateTime dataFim);
-    @Query("SELECT t FROM Transferencia t WHERE t.nomeOperadorTransacao = :nomeOperador")
+    @Query("SELECT t FROM Transferencia t JOIN t.conta c WHERE (:nomeOperador = t.nomeOperadorTransacao OR :nomeOperador = c.nomeResponsavel)")
     List<Transferencia> findByNomeOperadorTransacao(String nomeOperador);
-    @Query("SELECT t FROM Transferencia t WHERE t.dataTransferencia BETWEEN :dataInicio AND :dataFim AND t.nomeOperadorTransacao = :nomeOperador")
+    @Query("SELECT t FROM Transferencia t JOIN t.conta c WHERE t.dataTransferencia BETWEEN :dataInicio AND :dataFim AND (:nomeOperador = t.nomeOperadorTransacao OR :nomeOperador = c.nomeResponsavel)")
     List<Transferencia> findByDataTransferenciaBetweenAndNomeOperadorTransacao(
             LocalDateTime dataInicio, LocalDateTime dataFim, String nomeOperador);
 }


### PR DESCRIPTION
Ajuste na consulta do repositório para obter corretamente o Nome do Nome operador Transacionado.

Essa correção visa resolver o problema na consulta do banco de dados, permitindo que o Nome do Operador seja recuperado corretamente. A consulta agora realiza um join entre as entidades Transferencia e Conta, verificando se o nomeOperadorTransacao da transferência ou o nomeResponsavel da conta corresponde ao Nome operador Transacionado fornecido.